### PR TITLE
Separate the configuration into a specific state

### DIFF
--- a/kibana/client/init.sls
+++ b/kibana/client/init.sls
@@ -1,12 +1,8 @@
 {%- from "kibana/map.jinja" import client with context %}
 {%- if client.get('enabled', False) %}
 
-/etc/salt/minion.d/_kibana.conf:
-  file.managed:
-  - source: salt://kibana/files/_kibana.conf
-  - template: jinja
-  - user: root
-  - group: root
+include:
+  - kibana.client.service
 
 {%- for object_name, object in client.get('object', {}).iteritems() %}
 kibana_object_{{ object_name }}:

--- a/kibana/client/service.sls
+++ b/kibana/client/service.sls
@@ -1,0 +1,11 @@
+{%- from "kibana/map.jinja" import client with context %}
+{%- if client.get('enabled', False) %}
+
+/etc/salt/minion.d/_kibana.conf:
+  file.managed:
+  - source: salt://kibana/files/_kibana.conf
+  - template: jinja
+  - user: root
+  - group: root
+
+{%- endif %}


### PR DESCRIPTION
This patch separates the configuration of Kibana. This allow to
configure the client, restart the minion to read the conf and finally
apply the kibana.client.state to push objects.